### PR TITLE
Update Firebase and peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Once you've installed it, you can now install the addon itself:
 ember install ember-firebase-service
 ```
 
-*Versioning will be aligned with Firebase's MAJOR version. For example, if you want to use Firebase v4.x, you would need to depend on the v4.x of this addon.*
-
 ### Configuration
 
 Add your Firebase configuration in your app's `config/environment.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-firebase-service",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2980,16 +2980,16 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
-      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.1.tgz",
+      "integrity": "sha512-Pn7KPkH/M2JXoyoDHfdSjTBHTlnqe6rHo/vjsSvveA46dUP/GfDpcKWGfy/OBXKrIvKUVP7ZhyZo0Gb6jKB0cw==",
       "dev": true,
       "requires": {
         "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -3008,15 +3008,15 @@
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.11.tgz",
-      "integrity": "sha512-FH++PaoyTzfTAVuJ0gITNYEIcjT5G+D0671La27MU8Vvr6MTko+5YUZ4xS9QItyotSeRF4rMJ1KR7G8LSyySiA==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.12.tgz",
+      "integrity": "sha512-gko1NxRLJn+BMqDK6GBhcCDApD5rX5zhNfS7frl/uic8us9GnAuo6NtHuO0Q+AAjYB1Sv3YtPLXI7ckQEO9Wew==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "dom-storage": "2.1.0",
         "tslib": "^1.11.1",
         "xmlhttprequest": "1.8.0"
@@ -3037,9 +3037,9 @@
       "dev": true
     },
     "@firebase/auth": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
-      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.1.tgz",
+      "integrity": "sha512-qVJTmq/6l3/o6V93nAD+n1ExTywbKEFYbuuI1TZIUryy5KSXOFnxilmZI4yJeQSZ3ee06YiJsIRYRaYUeg6JQQ==",
       "dev": true,
       "requires": {
         "@firebase/auth-types": "0.10.1"
@@ -3058,12 +3058,12 @@
       "dev": true
     },
     "@firebase/component": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.19.tgz",
-      "integrity": "sha512-L0S3g8eqaerg8y0zox3oOHSTwn/FE8RbcRHiurnbESvDViZtP5S5WnhuAPd7FnFxa8ElWK0z1Tr3ikzWDv1xdQ==",
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.20.tgz",
+      "integrity": "sha512-UF9kBCco3U5AMJVNrup8kzOjksvmjmwL88vr/cL3BQ7DeTZWMf15iBOmBf+9HnhtPboN8Cw+84VT21aXGHBgNQ==",
       "dev": true,
       "requires": {
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -3076,16 +3076,16 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
-      "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.7.0.tgz",
+      "integrity": "sha512-pVio41uGhy6HNSk1uBHq9wTzO83bg2Jb527XFILIk4p/KFBbuQwKnQn+65SfnsDlElC1HjHBerTaonHLYevJqA==",
       "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.19",
-        "@firebase/database-types": "0.5.2",
+        "@firebase/component": "0.1.20",
+        "@firebase/database-types": "0.6.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "faye-websocket": "0.11.3",
         "tslib": "^1.11.1"
       },
@@ -3099,24 +3099,24 @@
       }
     },
     "@firebase/database-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-      "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.0.tgz",
+      "integrity": "sha512-ljpU7/uboCGqFSe9CNgwd3+Xu5N8YCunzfPpeueuj2vjnmmypUi4QWxgC3UKtGbuv1q+crjeudZGLxnUoO0h7w==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.6.1"
       }
     },
     "@firebase/firestore": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
-      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.0.0.tgz",
+      "integrity": "sha512-KHp5/yRmdQkpfGg8zotTJlUweXVsTe6Ip68iruc51VhYjWgmIb5QorelE1N5+O3kFqiDTOfBfeCXaO14bXk4wA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/firestore-types": "1.14.0",
+        "@firebase/component": "0.1.20",
+        "@firebase/firestore-types": "2.0.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "@firebase/webchannel-wrapper": "0.4.0",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
@@ -3133,19 +3133,19 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
-      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.0.0.tgz",
+      "integrity": "sha512-ZGb7p1SSQJP0Z+kc9GAUi+Fx5rJatFddBrS1ikkayW+QHfSIz0omU23OgSHcBGTxe8dJCeKiKA2Yf+tkDKO/LA==",
       "dev": true
     },
     "@firebase/functions": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
-      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.0.tgz",
+      "integrity": "sha512-XDVyDLBJwGCqI/agGxRrPYfit7HTcOSXTrjlC8NJr5+h3zzUuAB/+VEfaa8mSEZR+0AjY67B1cPed0WuXsU48g==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/functions-types": "0.3.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/functions-types": "0.4.0",
         "@firebase/messaging-types": "0.5.0",
         "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
@@ -3160,20 +3160,20 @@
       }
     },
     "@firebase/functions-types": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.17.tgz",
-      "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
+      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.17.tgz",
-      "integrity": "sha512-AE/TyzIpwkC4UayRJD419xTqZkKzxwk0FLht3Dci8WI2OEKHSwoZG9xv4hOBZebe+fDzoV2EzfatQY8c/6Avig==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.18.tgz",
+      "integrity": "sha512-el1PvpVbsNb6uXIoSKzI0A52K+h8yeLvI1tjMqdjnp+0xZQr2pwRJcBMvzt6aLrgBT06jMVB3R+fxfxxqgoO2g==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "idb": "3.0.2",
         "tslib": "^1.11.1"
       },
@@ -3199,15 +3199,15 @@
       "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.1.tgz",
-      "integrity": "sha512-iev/ST9v0xd/8YpGYrZtDcqdD9J6ZWzSuceRn8EKy5vIgQvW/rk2eTQc8axzvDpQ36ZfphMYuhW6XuNrR3Pd2Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.2.tgz",
+      "integrity": "sha512-5FzxklNgZS5S03p0eKvhsj6mLGG06qgnaLEbLluKeuDJ5STR/+gWySuCdP9BhcJCsTGN77Qwa06MLK/d46R0rQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "idb": "3.0.2",
         "tslib": "^1.11.1"
       },
@@ -3227,16 +3227,16 @@
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
-      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.3.tgz",
+      "integrity": "sha512-oP7EvI8qvlAJgVGY25ZabXl/Xb82ykxKyYP+xNDs0Imdg+8GBOfzqQiGpM+BqovhTTdGPcpJmry7JYwpWMZ8bg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -3274,16 +3274,16 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.28.tgz",
-      "integrity": "sha512-4zSdyxpt94jAnFhO8toNjG8oMKBD+xTuBIcK+Nw8BdQWeJhEamgXlupdBARUk1uf3AvYICngHH32+Si/dMVTbw==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.29.tgz",
+      "integrity": "sha512-VuKoubiE/kEfp5FXx7Nxw5c1TRYApBey7zdwTu/+U7qZFofHnUGDZs1vu82xTRnwbPtxh228FOwpZZ0iTrpVtA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
-        "@firebase/installations": "0.4.17",
+        "@firebase/component": "0.1.20",
+        "@firebase/installations": "0.4.18",
         "@firebase/logger": "0.2.6",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -3302,14 +3302,14 @@
       "dev": true
     },
     "@firebase/storage": {
-      "version": "0.3.43",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.43.tgz",
-      "integrity": "sha512-Jp54jcuyimLxPhZHFVAhNbQmgTu3Sda7vXjXrNpPEhlvvMSq4yuZBR6RrZxe/OrNVprLHh/6lTCjwjOVSo3bWA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.0.tgz",
+      "integrity": "sha512-6AG1g2WbbVxscf40rHar+IAk6ocvg8IOM5NmlXHxcXt9KENSQYGNiHsGEROm+W7FOx2izuHTEfqPUr8Qh5EwNA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.19",
+        "@firebase/component": "0.1.20",
         "@firebase/storage-types": "0.3.13",
-        "@firebase/util": "0.3.2",
+        "@firebase/util": "0.3.3",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -3328,9 +3328,9 @@
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.2.tgz",
-      "integrity": "sha512-Dqs00++c8rwKky6KCKLLY2T1qYO4Q+X5t+lF7DInXDNF4ae1Oau35bkD+OpJ9u7l1pEv7KHowP6CUKuySCOc8g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.3.tgz",
+      "integrity": "sha512-VBuyR+6QAvrumzEtp3hMTRYkDnvsWuDMzqObca2Phn30RJTEV24P1RSMG5fw8LbSE+KkD9WiiiMJN++YoeyFaA==",
       "dev": true,
       "requires": {
         "tslib": "^1.11.1"
@@ -3659,9 +3659,9 @@
           }
         },
         "@types/node": {
-          "version": "12.19.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.1.tgz",
-          "integrity": "sha512-/xaVmBBjOGh55WCqumLAHXU9VhjGtmyTGqJzFBXRWZzByOXI5JAJNx9xPVGEsNizrNwcec92fQMj458MWfjN1A==",
+          "version": "12.19.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.2.tgz",
+          "integrity": "sha512-SRH6QM0IMOBBFmDiJ75vlhcbUEYEquvSuhsVW9ijG20JvdFTfOrB1p6ddZxz5y/JNnbf+9HoHhjhOVSX2hsJyA==",
           "dev": true
         },
         "semver": {
@@ -14689,25 +14689,25 @@
       }
     },
     "firebase": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
-      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.0.0.tgz",
+      "integrity": "sha512-0JMwNGg5CeoYBJ27QuDYJe1pYdJ+lspKbK1Pr+aNtYBfJfZTNy265rRroQsSOTGbXiT6cUqObVPeGwnbi8wZHw==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.6.0",
-        "@firebase/app": "0.6.11",
+        "@firebase/analytics": "0.6.1",
+        "@firebase/app": "0.6.12",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.15.0",
-        "@firebase/database": "0.6.13",
-        "@firebase/firestore": "1.18.0",
-        "@firebase/functions": "0.5.1",
-        "@firebase/installations": "0.4.17",
-        "@firebase/messaging": "0.7.1",
-        "@firebase/performance": "0.4.2",
+        "@firebase/auth": "0.15.1",
+        "@firebase/database": "0.7.0",
+        "@firebase/firestore": "2.0.0",
+        "@firebase/functions": "0.6.0",
+        "@firebase/installations": "0.4.18",
+        "@firebase/messaging": "0.7.2",
+        "@firebase/performance": "0.4.3",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.28",
-        "@firebase/storage": "0.3.43",
-        "@firebase/util": "0.3.2"
+        "@firebase/remote-config": "0.1.29",
+        "@firebase/storage": "0.4.0",
+        "@firebase/util": "0.3.3"
       }
     },
     "fireworm": {
@@ -15144,9 +15144,9 @@
       }
     },
     "gaxios": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
-      "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
+      "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -15172,6 +15172,27 @@
       "requires": {
         "gaxios": "^3.0.0",
         "json-bigint": "^1.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
+          "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        }
       }
     },
     "gensync": {
@@ -15418,16 +15439,16 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.2.tgz",
-      "integrity": "sha512-X9EUX8R+kIpsf55KdSPhFWF0RNyBGuBc1zeYc/5Sjuk65eIYqq91rINJVBD22pp+w/PuM2fasHiA6H2xYjxTIQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
       "dev": true,
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^3.0.0",
+        "gaxios": "^4.0.0",
         "gcp-metadata": "^4.2.0",
         "gtoken": "^5.0.4",
         "jws": "^4.0.0",
@@ -15517,12 +15538,12 @@
       "dev": true
     },
     "gtoken": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.4.tgz",
-      "integrity": "sha512-U9wnSp4GZ7ov6zRdPuRHG4TuqEWqRRgT1gfXGNArhzBUn9byrPeH8uTmBWU/ZiWJJvTEmkjhDIC3mqHWdVi3xQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
+      "integrity": "sha512-wvjkecutFh8kVfbcdBdUWqDRrXb+WrgD79DBDEYf1Om8S1FluhylhtFjrL7Tx69vNhh259qA3Q1P4sPtb+kUYw==",
       "dev": true,
       "requires": {
-        "gaxios": "^3.0.0",
+        "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
         "jws": "^4.0.0",
         "mime": "^2.2.0"
@@ -18821,9 +18842,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.28.tgz",
-          "integrity": "sha512-EM/qFeRH8ZCD+TlsaIPULyyFm9vOhFIvgskY2JmHbEsWsOPgN+rtjSXrcHGgJpob4Nu17VfO95FKewr0XY7iOQ==",
+          "version": "13.13.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.29.tgz",
+          "integrity": "sha512-WPGpyEDx4/F4Rx1p1Zar8m+JsMxpSY/wNFPlyNXWV+UzJwkYt3LQg2be/qJgpsLdVJsfxTR5ipY6rv2579jStQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-firebase-service",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Exposes a service that's a direct representation of Firebase",
   "keywords": [
     "ember-addon",
@@ -69,14 +69,14 @@
     "eslint-plugin-ember": "^9.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^11.1.0",
-    "firebase": "^7.24.0",
+    "firebase": "^8.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.5.0",
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "firebase": "^7.24.0"
+    "firebase": "^6.6.2 || ^7.24.0 || ^8.0.0"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
This marks the change where we will no longer align the package version to the Firebase version. Moving forward, this is how version bumps will happen *whenever Firebase does theirs*:

- MAJOR version will only happen whenever Firebase actually breaks this addon
- MINOR version will only happen whenever Firebase releases a new MAJOR version that doesn't break this addon. Hence, the update here will simply be to bump the `peerDependencies` to include that new MAJOR version.

Emphasizing that the bullet points above are only for cases *whenever Firebase updates their versions*. The project still follows semantic versioning guidelines in general.