### PR TITLE
Support FastBoot by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ let ENV = {
 }
 ```
 
-Import the Firebase features that you need in your app's `ember-cli-build.js`.
+Import the Firebase products that you need in your app's `ember-cli-build.js` using the format of `vendor/ember-firebase-service/firebase/firebase-<product>.js`. Note that you don't need to import `firebase-app.js` as it's automatically done for you.
 
 ```javascript
 'use strict';
@@ -62,14 +62,29 @@ module.exports = function (defaults) {
 
   ...
 
-  app.import('node_modules/firebase/firebase-auth.js');
-  app.import('node_modules/firebase/firebase-firestore.js');
+  app.import('vendor/ember-firebase-service/firebase/firebase-auth.js');
+  app.import('vendor/ember-firebase-service/firebase/firebase-firestore.js');
 
   return app.toTree();
 };
 ```
 
-> You don't need to import `firebase-app.js` as it's automatically done for you
+#### FastBoot
+
+The Firebase products that you included in your `ember-cli-build.js` are already transformed to not run in FastBoot. This is because Firebase requires different modules when running under Node.js as opposed to the browser. To use the Node.js modules, create a FastBoot-only initializer and import it from there.
+
+```
+export function initialize() {
+  if (typeof FastBoot !== 'undefined') {
+    FastBoot.require('firebase/auth');
+    FastBoot.require('firebase/firestore');
+  }
+}
+
+export default {
+  initialize
+};
+```
 
 Usage
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module.exports = function (defaults) {
 
 The Firebase products that you included in your `ember-cli-build.js` are already transformed to not run in FastBoot. This is because Firebase requires different modules when running under Node.js as opposed to the browser. To use the Node.js modules, create a FastBoot-only initializer and import it from there.
 
-```
+```javascript
 export function initialize() {
   if (typeof FastBoot !== 'undefined') {
     FastBoot.require('firebase/auth');

--- a/README.md
+++ b/README.md
@@ -95,15 +95,13 @@ Inject the `firebase` service and use it as you would use Firebase normally.
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
-export default Component.extend({
-  firebase: service(),
+export default class MyComponent extends Component {
+  @service firebase;
 
-  init(...args) {
-    this._super(...args);
-
+  signIn() {
     this.firebase.auth().signInWithEmailAndPassword('foo', 'bar');
   }
-});
+}
 ```
 
 Contributing

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = {
 
   treeForVendor(defaultTree) {
     let browserVendorLib = new Funnel('node_modules', {
-      destDir: 'fastboot-shims',
-      files: ['firebase/firebase-app.js'],
+      destDir: 'ember-firebase-service',
+      include: ['firebase/firebase-*.js'],
     });
 
     browserVendorLib = map(browserVendorLib, content => (
@@ -25,7 +25,7 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
-    app.import('vendor/fastboot-shims/firebase/firebase-app.js', {
+    app.import('vendor/ember-firebase-service/firebase/firebase-app.js', {
       type: 'vendor',
       prepend: true,
     });


### PR DESCRIPTION
This addon has supported FastBoot for a while now but there was no clear way for the users to make use of it.

This PR contains changes that:
- Does a fastboot-transform on Firebase browser modules
- Updates the README usage for FastBoot support