### PR TITLE
Fix import convention and unable to resolve service

### DIFF
--- a/addon/services/firebase.d.ts
+++ b/addon/services/firebase.d.ts
@@ -1,7 +1,15 @@
 /* eslint @typescript-eslint/no-empty-interface: 'off' */
 
-declare module 'ember-firebase-service/services/firebase' {
-  import firebase from 'firebase';
+import firebase from 'firebase/app';
 
-  export default interface FirebaseService extends firebase.app.App {}
+interface FirebaseInterface extends firebase.app.App {}
+
+declare module 'ember-firebase-service/services/firebase' {
+  export default interface FirebaseService extends FirebaseInterface {}
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'firebase': FirebaseInterface;
+  }
 }

--- a/addon/services/firebase.ts
+++ b/addon/services/firebase.ts
@@ -1,7 +1,7 @@
 import { getOwner } from '@ember/application';
 import ApplicationInstance from '@ember/application/instance';
 
-import firebase from 'firebase';
+import firebase from 'firebase/app';
 
 export default {
   isServiceFactory: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-firebase-service",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-firebase-service",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Exposes a service that's a direct representation of Firebase",
   "keywords": [
     "ember-addon",

--- a/services/firebase.d.ts
+++ b/services/firebase.d.ts
@@ -1,7 +1,15 @@
 /* eslint @typescript-eslint/no-empty-interface: 'off' */
 
-declare module 'ember-firebase-service/services/firebase' {
-  import firebase from 'firebase';
+import firebase from 'firebase/app';
 
-  export default interface FirebaseService extends firebase.app.App {}
+interface FirebaseInterface extends firebase.app.App {}
+
+declare module 'ember-firebase-service/services/firebase' {
+  export default interface FirebaseService extends FirebaseInterface {}
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'firebase': FirebaseInterface;
+  }
 }

--- a/vendor/shims/firebase.js
+++ b/vendor/shims/firebase.js
@@ -9,5 +9,5 @@
     return { default: firebase, __esModule: true };
   }
 
-  define('firebase', [], vendorModule);
+  define('firebase/app', [], vendorModule);
 })();


### PR DESCRIPTION
Firebase recommends imports to be of

```javascript
import firebase from 'firebase/app';
```

The vendor-shim has been updated to adhere to that convention. This means that this may cause breakages to anyone using

```javascript
import firebase from 'firebase';
```

Lastly, this PR fixes the service resolution:

```javascript
@service firebase; // previously, only this type of service injection works
@service('firebase') firebaseService; // after pr merge, this now works too
```